### PR TITLE
Update Kia Niro EV generations: Add Wikipedia reference and standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Kia Niro EV
 
-## Related vehicles
+This repository contains signal set configurations for the Kia Niro EV, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Kia Niro EV.
 
-- [Hyundai Kona Electric](https://github.com/ElectricSidecar/Hyundai-Kona-Electric)
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Kia_Niro"
+
 generations:
   - name: "First Generation (DE)"
     start_year: 2018


### PR DESCRIPTION
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard template
- Verified generational data matches Wikipedia article (Kia Niro EV launched 2018, second gen EV debuted April 2022)
